### PR TITLE
Support Page Templates for Custom Post Types

### DIFF
--- a/views/admin/import/template/_other_template.php
+++ b/views/admin/import/template/_other_template.php
@@ -187,7 +187,7 @@
 									<div class="input">
 										<select name="page_template" id="page_template">
 											<option value='default'><?php _e('Default', 'wp_all_import_plugin') ?></option>
-											<?php page_template_dropdown($post['page_template']); ?>
+											<?php page_template_dropdown($post['page_template'], $post_type); ?>
 										</select>
 									</div>
 								</div>


### PR DESCRIPTION
Page Template dropdown currently displays Page Templates only, rather than templates for the chosen Post Type.
https://developer.wordpress.org/reference/functions/page_template_dropdown/